### PR TITLE
Clarify ADDRESS_ASSIGN, ROUTE_ADVERTISEMENT roles

### DIFF
--- a/draft-age-masque-connect-ip.md
+++ b/draft-age-masque-connect-ip.md
@@ -177,7 +177,7 @@ these new capsules.
 ### ADDRESS_ASSIGN Capsule
 
 The ADDRESS_ASSIGN capsule allows an endpoint to inform its peer that it has
-assigned an IP address to it. The ADDRESS_ASSIGN capsule allows assigning a
+assigned an IP address or prefix to it. The ADDRESS_ASSIGN capsule allows assigning a
 prefix which can contain multiple addresses. Any of these addresses can be used
 as the source address on IP packets originated by the receiver of this
 capsule. This capsule uses a Capsule Type of 0xfff100. Its value uses the


### PR DESCRIPTION
This change adds text that addresses conveyed by ADDRESS_ASSIGN can be
used in the "source address" field of an IP packet, while addresses
conveyed by ROUTE_ADVERTISEMENT can be used in the "destination
address" field.

While we're here, also add a small clarification when a prefix is
assigned/advertised that *any* of these addresses can be used in the
source/destination field, respectively. A future extension could
create semantics for these addreses, but that is not called out in the
text at this time.

Closes: #25