### PR TITLE
Client configuration with URI template update

### DIFF
--- a/draft-ietf-masque-connect-ip.md
+++ b/draft-ietf-masque-connect-ip.md
@@ -106,12 +106,12 @@ those are referred to as "intermediaries" in this document.
 
 Clients are configured to use IP Proxying over HTTP via an URI Template
 {{!TEMPLATE=RFC6570}}. The URI template MAY contain two variables: "target" and
-"ip_proto". Examples are shown below:
+"ipproto". Examples are shown below:
 
 ~~~
-https://masque.example.org/.well-known/masque/ip/{target}/{ip_proto}/
-https://proxy.example.org:4443/masque?t={target}&i={ip_proto}
-https://proxy.example.org:4443/masque{?target,ip_proto}
+https://masque.example.org/.well-known/masque/ip/{target}/{ipproto}/
+https://proxy.example.org:4443/masque/ip?t={target}&i={ipproto}
+https://proxy.example.org:4443/masque/ip{?target,ipproto}
 https://masque.example.org/?user=bob
 ~~~
 {: #fig-template-examples title="URI Template Examples"}
@@ -130,12 +130,12 @@ The following requirements apply to the URI Template:
       of the URI.
 
    *  The URI template MAY contain the two variables "target" and
-      "ip_proto" and MAY contain other variables.
+      "ipproto" and MAY contain other variables.
 
    *  The URI Template MUST NOT contain any non-ASCII unicode characters
       and MUST only contain ASCII characters in the range 0x21-0x7E
       inclusive (note that percent-encoding is allowed; see Section 2.1
-      of [URI]).
+      of {{!URI=RFC3986}}.
 
    *  The URI Template MUST NOT use Reserved Expansion ("+" operator),
       Fragment Expansion ("#" operator), Label Expansion with Dot-
@@ -154,7 +154,7 @@ with proxy configuration interfaces that only allow the user to configure the
 proxy host and the proxy port.  Client implementations of this specification
 that are constrained by such limitations MAY attempt to access IP proxying
 capabilities using the default template, which is defined as:
-"https://$PROXY_HOST:$PROXY_PORT/.well-known/masque/ ip/{target}/{ip_proto}/"
+"https://$PROXY_HOST:$PROXY_PORT/.well-known/masque/ ip/{target}/{ipproto}/"
 where $PROXY_HOST and $PROXY_PORT are the configured host and port of the IP
 proxy respectively.  IP proxy deployments SHOULD offer service at this location
 if they need to interoperate with such clients. The well known suffic masque has

--- a/draft-ietf-masque-connect-ip.md
+++ b/draft-ietf-masque-connect-ip.md
@@ -231,7 +231,7 @@ the value is "\*", or the variable is not included, the client is requesting to
 use any IP protocol.  {: spacing="compact"}
 
 Also note that this URI Template expansion requires using
-percent-encoding,e.g. of ":" and "*", so for example if the target_host is
+percent-encoding,e.g. of ":" and "\*", so for example if the target_host is
 "2001:db8::42", it will be encoded in the URI as "2001%3Adb8%3A%3A42".
 
 ## Capsules

--- a/draft-ietf-masque-connect-ip.md
+++ b/draft-ietf-masque-connect-ip.md
@@ -109,12 +109,56 @@ Clients are configured to use IP Proxying over HTTP via an URI Template
 "ip_proto". Examples are shown below:
 
 ~~~
-https://masque.example.org/{target}/{ip_proto}/
-https://proxy.example.org:4443/masque?t={target}&p={ip_proto}
+https://masque.example.org/.well-known/masque/ip/{target}/{ip_proto}/
+https://proxy.example.org:4443/masque?t={target}&i={ip_proto}
 https://proxy.example.org:4443/masque{?target,ip_proto}
 https://masque.example.org/?user=bob
 ~~~
 {: #fig-template-examples title="URI Template Examples"}
+
+The following requirements apply to the URI Template:
+
+   *  The URI Template MUST be a level 3 template or lower.
+
+   *  The URI Template MUST be in absolute form, and MUST include non-
+      empty scheme, authority and path components.
+
+   *  The path component of the URI Template MUST start with a slash
+      "/".
+
+   *  All template variables MUST be within the path or query components
+      of the URI.
+
+   *  The URI template MAY contain the two variables "target" and
+      "ip_proto" and MAY contain other variables.
+
+   *  The URI Template MUST NOT contain any non-ASCII unicode characters
+      and MUST only contain ASCII characters in the range 0x21-0x7E
+      inclusive (note that percent-encoding is allowed; see Section 2.1
+      of [URI]).
+
+   *  The URI Template MUST NOT use Reserved Expansion ("+" operator),
+      Fragment Expansion ("#" operator), Label Expansion with Dot-
+      Prefix, Path Segment Expansion with Slash-Prefix, nor Path-Style
+      Parameter Expansion with Semicolon-Prefix.
+
+Clients SHOULD validate the requirements above; however, clients MAY use a
+general-purpose URI Template implementation that lacks this specific validation.
+If a client detects that any of the requirements above are not met by a URI
+Template, the client MUST reject its configuration and abort the request without
+sending it to the IP proxy.
+
+Since the original HTTP CONNECT method allowed conveying the target host and
+port but not the scheme, proxy authority, path, nor query, there exist clients
+with proxy configuration interfaces that only allow the user to configure the
+proxy host and the proxy port.  Client implementations of this specification
+that are constrained by such limitations MAY attempt to access IP proxying
+capabilities using the default template, which is defined as:
+"https://$PROXY_HOST:$PROXY_PORT/.well-known/masque/ ip/{target}/{ip_proto}/"
+where $PROXY_HOST and $PROXY_PORT are the configured host and port of the IP
+proxy respectively.  IP proxy deployments SHOULD offer service at this location
+if they need to interoperate with such clients. The well known suffic masque has
+been registreed by {{CONNECT-UDP}}.
 
 # The CONNECT-IP Protocol
 
@@ -742,6 +786,7 @@ Capsule Types" registry created by {{HTTP-DGRAM}}:
 | 0xfff102 | ROUTE_ADVERTISEMENT | Route Advertisement | This Document |
 {: #iana-capsules-table title="New Capsules"}
 
+
 --- back
 
 # Acknowledgments
@@ -750,3 +795,7 @@ Capsule Types" registry created by {{HTTP-DGRAM}}:
 The design of this method was inspired by discussions in the MASQUE working
 group around {{?PROXY-REQS=I-D.ietf-masque-ip-proxy-reqs}}. The authors would
 like to thank participants in those discussions for their feedback.
+
+Most of the text on client configuration is based on the corresponding text in
+{{CONNECT-UDP}}.
+

--- a/draft-ietf-masque-connect-ip.md
+++ b/draft-ietf-masque-connect-ip.md
@@ -107,9 +107,8 @@ those are referred to as "intermediaries" in this document.
 Clients are configured to use IP Proxying over HTTP via an URI Template
 {{!TEMPLATE=RFC6570}}. The URI template MAY contain two variables: "target" and
 "ipproto" ({{scope}}). The optionality of the variables needs to be considered
-when defining the template so that either the variable is self identfying or it
-works to exclude it in the syntax. For example first path segment in absolute
-URIs cannot be empty.
+when defining the template so that either the variable is self-identifying or it
+works to exclude it in the syntax.
 
 Examples are shown below:
 
@@ -229,10 +228,6 @@ the "Assigned Internet Protocol Numbers" IANA registry. If present, it specifies
 that a client only wants to proxy a specific IP protocol for this request. If
 the value is "\*", or the variable is not included, the client is requesting to
 use any IP protocol.  {: spacing="compact"}
-
-Also note that this URI Template expansion requires using
-percent-encoding,e.g. of ":" and "\*", so for example if the target_host is
-"2001:db8::42", it will be encoded in the URI as "2001%3Adb8%3A%3A42".
 
 ## Capsules
 

--- a/draft-ietf-masque-connect-ip.md
+++ b/draft-ietf-masque-connect-ip.md
@@ -109,7 +109,7 @@ Clients are configured to use IP Proxying over HTTP via an URI Template
 "ipproto" ({{scope}}). The optionality of the variables needs to be considered
 when defining the template so that either the variable is self identfying or it
 works to exclude it in the syntax. For example first path segment in absolute
-URIs can not be empty.
+URIs cannot be empty.
 
 Examples are shown below:
 


### PR DESCRIPTION
Proposal for update to client configuration section. Would address #46.

I would note that I think this proposal have some short comings that should be resolved before accepting.
* With the exception to the well known proposal here there is overlap with the corresponding example in connect-up and likely some separation with connect-UDP is desired. 
* Connect-UDP did register the suffix as noted in text. However, should the URI paths under masque be managed somehow by IANA too? 

Fixes #46 
Fixes #53 
Fixes #55 