### PR TITLE
Add ADDRESS_REQUEST Capsule to VPN example

### DIFF
--- a/draft-ietf-masque-connect-ip.md
+++ b/draft-ietf-masque-connect-ip.md
@@ -778,9 +778,16 @@ capsule-protocol = ?1
                               :status = 200
                               capsule-protocol = ?1
 
+STREAM(44): CAPSULE
+Capsule Type = ADDRESS_REQUEST
+(Request ID = 1
+ IP Version = 4
+ IP Address = 0.0.0.0
+ IP Prefix Length = 32)
+
                               STREAM(44): CAPSULE
                               Capsule Type = ADDRESS_ASSIGN
-                              (Request ID = 0
+                              (Request ID = 1
                                IP Version = 4
                                IP Address = 192.0.2.11
                                IP Prefix Length = 32)


### PR DESCRIPTION
In the ADDRESS_ASSIGN Capsule section, the Remote Access VPN example is explicitly called out and says that in such deployments, an `ADDRESS_REQUEST` Capsule MUST be sent. Let's actually do that in the example.