### PR TITLE
Edits to ADDRESS_REQUEST regarding replies

### DIFF
--- a/draft-ietf-masque-connect-ip.md
+++ b/draft-ietf-masque-connect-ip.md
@@ -495,13 +495,13 @@ sender's preference for the prefix length it is requesting.
 Upon receiving the ADDRESS_REQUEST capsule, an endpoint SHOULD assign one or
 more IP addresses to its peer, and then respond with an ADDRESS_ASSIGN capsule
 to inform the peer of the assignment. For each Requested Address, the receiver
-of the ADDRESS_REQUEST capsule MUST respond with a Assigned Address with a
+of the ADDRESS_REQUEST capsule SHALL respond with a Assigned Address with a
 matching Request ID. If the requested address was assigned, the IP Address and
 IP Prefix Length fields in the Assigned Address response SHALL be set to the
 assigned values. If the requested address was not assigned, the IP Address SHALL
 be all-zero and the IP Prefix Length SHALL be the maximum length (0.0.0.0/32 or
-::/128) to indicate that no address was assigned. Non-assignments SHOULD NOT be
-repeated in future ADDRESS_ASSIGN capsules. Note that other Assigned Address
+::/128) to indicate that no address was assigned. These address rejections SHOULD NOT be
+included in subsequent ADDRESS_ASSIGN capsules. Note that other Assigned Address
 entries that do not correspond to any Request ID can also be contained in the
 same ADDRESS_ASSIGN response.
 

--- a/draft-ietf-masque-connect-ip.md
+++ b/draft-ietf-masque-connect-ip.md
@@ -492,17 +492,18 @@ requesting an address of that address family but does not have a preference for
 a specific address. In that scenario, the prefix length still indicates the
 sender's preference for the prefix length it is requesting.
 
-Upon receiving the ADDRESS_REQUEST capsule, an endpoint SHOULD assign one or more
-IP addresses to its peer, and then respond with an ADDRESS_ASSIGN capsule to inform
-the peer of the assignment. For each Requested Address, the receiver of the
-ADDRESS_REQUEST capsule SHOULD respond with a Assigned Address with a matching
-Request ID. If the requested address was assigned, the IP Address and
-IP Prefix Length fields in the Assigned Address response SHALL be set to the assigned
-values. If the requested address was not assigned, the IP Address SHALL be all-zero
-and the IP Prefix Length SHALL be the maximum length (0.0.0.0/32 or ::/128) to
-indicate that no address was assigned. Note that other Assigned Address entries
-that do not correspond to any Request ID can also be contained in the same ADDRESS_ASSIGN
-response.
+Upon receiving the ADDRESS_REQUEST capsule, an endpoint SHOULD assign one or
+more IP addresses to its peer, and then respond with an ADDRESS_ASSIGN capsule
+to inform the peer of the assignment. For each Requested Address, the receiver
+of the ADDRESS_REQUEST capsule MUST respond with a Assigned Address with a
+matching Request ID. If the requested address was assigned, the IP Address and
+IP Prefix Length fields in the Assigned Address response SHALL be set to the
+assigned values. If the requested address was not assigned, the IP Address SHALL
+be all-zero and the IP Prefix Length SHALL be the maximum length (0.0.0.0/32 or
+::/128) to indicate that no address was assigned. Non-assignments SHOULD NOT be
+repeated in future ADDRESS_ASSIGN capsules. Note that other Assigned Address
+entries that do not correspond to any Request ID can also be contained in the
+same ADDRESS_ASSIGN response.
 
 If an endpoint receives an ADDRESS_REQUEST capsule that contains zero Requested
 Addresses, it MUST abort the IP proxying request stream.


### PR DESCRIPTION
s/SHOULD/MUST/ regarding replying to add requests.

Indicate that endpoints responding to ADDRESS_REQUEST capsules SHOULD NOT send repeat non-assignments in future ADDRESS_ASSIGN capsules.

Closes #103 #106

---
Please wordsmith away.