### PR TITLE
Add IANA expert guidance

### DIFF
--- a/draft-ietf-masque-connect-ip.md
+++ b/draft-ietf-masque-connect-ip.md
@@ -1438,6 +1438,10 @@ There are initially two entries in this registry:
 |      ip      |  IP Proxying | This Document |
 {: #iana-suffixes-table title="New MASQUE URI Suffixes"}
 
+Designated experts for this registry are advised that they should approve all
+requests unless they believe the requested Path Segment will conflict with
+future IETF work.
+
 ## Updates to masque Well-Known URI {#iana-uri}
 
 This document will request IANA to update the entry for the "masque"


### PR DESCRIPTION
Based on [John's AD review](https://mailarchive.ietf.org/arch/msg/masque/nJHNU4kB3qBaxhj2LyipSkC4rX0/):

> ### Section 13.2, expert review guidance missing
> 
> Expert review registries are supposed to provide guidance, see Section 4.5 of [IANA-POLICY]:
>
>> The required documentation and review criteria, giving clear guidance to the designated expert, should be provided when defining the registry. [...]
> 
> I don't see where you provide this guidance?