### PR TITLE
Add 3xx example

### DIFF
--- a/draft-ietf-masque-connect-ip.md
+++ b/draft-ietf-masque-connect-ip.md
@@ -367,7 +367,9 @@ requirements:
   Capsule Protocol; see {{Section 3.2 of HTTP-DGRAM}}.
 
 If any of these requirements are not met, the client MUST treat this proxying
-attempt as failed and abort the request.
+attempt as failed and abort the request. As an example, any status code in the
+3xx range will be treated as a failure and cause the client to abort the
+request.
 
 For example, the server could respond with:
 


### PR DESCRIPTION
Based on [Nancy's SECDIR review](https://mailarchive.ietf.org/arch/msg/masque/IchrEjE4opH3qgtET5Z8GR11VZE/):

> The document is well written and straightforward in its descriptions.
> I only have one minor nit.
>
> Nits:
> Section 4.5 - It would be good to clarify some error/unsuccessful codes that speak explicitly to the proxy setup being unsuccessful as well. I presume codes NOT in 2xx are deemed to be error/unsuccessful like 305, 407, et al though not sure they either apply or not apply. Perhaps adding a clause to the first bullet to clarify That status codes of anything BUT 2xx should be deemed as unsuccessful And must then abort the request.